### PR TITLE
feat: unify media mapping with media_mapping.yaml

### DIFF
--- a/app/media/media.py
+++ b/app/media/media.py
@@ -736,19 +736,18 @@ class Media:
         if not meta_info.get_name() or not meta_info.type:
             log.warn("【Rmt】%s 未识别出有效信息！" % meta_info.org_string)
             return None
+        # 应用 media_mapping
+        mapping, mapped_tmdb_info = self.__apply_media_mapping(meta_info,
+                                                                  chinese=chinese,
+                                                                  append_to_response=append_to_response)
+        # tmdbid+type 直接命中时直接返回
+        if mapped_tmdb_info:
+            meta_info.set_tmdb_info(mapped_tmdb_info)
+            return meta_info
         if mtype:
             meta_info.type = mtype
         media_key = self.__make_cache_key(meta_info)
-        tmdb_id = Config().get_tmdb_id_mapping(title)
-        if tmdb_id:
-            media_type, tmdb_id = tmdb_id
-            log.info("【Meta】func[get_media_info]get_tmdb_id_mapping：[%s][%s]" % (tmdb_id, title))
-            media_type = MediaType.MOVIE if media_type == "movie" else MediaType.TV if media_type == "tv" else media_type
-            file_media_info = self.get_tmdb_info(mtype=media_type,
-                                                     tmdbid=tmdb_id,
-                                                     chinese=chinese,
-                                                     append_to_response=append_to_response)
-        elif not cache or not self.meta.get_meta_data_by_key(media_key):
+        if not cache or not self.meta.get_meta_data_by_key(media_key):
             # 缓存没有或者强制不使用缓存
             if meta_info.type != MediaType.TV and not meta_info.year:
                 file_media_info = self.__search_multi_tmdb(file_media_name=meta_info.get_name())
@@ -831,6 +830,47 @@ class Media:
         # 赋值TMDB信息并返回
         meta_info.set_tmdb_info(file_media_info)
         return meta_info
+
+    def __apply_media_mapping(self, meta_info, chinese=None, append_to_response=None):
+        """
+        查询 media_mapping 并应用映射。
+        返回 (mapping, tmdb_info)：
+          - mapping: dict 或 None（未命中时 None）
+          - tmdb_info: tmdbid+type 直接命中时返回 TMDB 详情，否则 None
+        """
+        mapping = Config().get_media_mapping(meta_info.raw_name or meta_info.get_name())
+        if not mapping:
+            return None, None
+
+        media_type = mapping.get("type")
+        tmdbid = mapping.get("tmdbid")
+        mapped_title = mapping.get("title")
+
+        if tmdbid and media_type:
+            # tmdbid + type 命中：直接查询 TMDB 详情，跳过搜索
+            log.info("【Meta】func[__apply_media_mapping]media_mapping tmdbid命中：[%s][%s]" % (tmdbid, meta_info.raw_name))
+            mtype = MediaType.MOVIE if media_type == "movie" else MediaType.TV
+            tmdb_info = self.get_tmdb_info(mtype=mtype, tmdbid=tmdbid,
+                                            chinese=chinese,
+                                            append_to_response=append_to_response)
+            return mapping, tmdb_info
+
+        if mapped_title:
+            # title 命中：覆盖 meta_info 的搜索名称
+            log.info("【Meta】func[__apply_media_mapping]media_mapping title命中：[%s]->[%s]" % (meta_info.get_name(), mapped_title))
+            # 根据当前 get_name() 优先级覆盖对应字段
+            if meta_info.cn_name and StringUtils.is_all_chinese(meta_info.cn_name):
+                meta_info.cn_name = mapped_title
+            elif meta_info.en_name:
+                meta_info.en_name = mapped_title
+            else:
+                meta_info.cn_name = mapped_title
+
+        if media_type and not tmdbid:
+            # type 命中（无 tmdbid）：覆盖媒体类型
+            meta_info.type = MediaType.MOVIE if media_type == "movie" else MediaType.TV
+
+        return mapping, None
 
     def __insert_media_cache(self, media_key, file_media_info):
         """
@@ -936,18 +976,18 @@ class Media:
                     if not meta_info.get_name() or not meta_info.type:
                         log.warn("【Rmt】%s 未识别出有效信息！" % meta_info.org_string)
                         continue
+                    # 应用 media_mapping
+                    mapping, mapped_tmdb_info = self.__apply_media_mapping(meta_info,
+                                                                              chinese=chinese,
+                                                                              append_to_response=append_to_response)
+                    if mapped_tmdb_info:
+                        # tmdbid+type 直接命中，跳过缓存/搜索
+                        meta_info.set_tmdb_info(mapped_tmdb_info)
+                        return_media_infos[file_path] = meta_info
+                        continue
                     # 区配缓存及TMDB
                     media_key = self.__make_cache_key(meta_info)
-                    tmdb_id = Config().get_tmdb_id_mapping(file_name)
-                    if tmdb_id:
-                        media_type, tmdb_id = tmdb_id
-                        log.info("【Meta】func[get_media_info_on_files]get_tmdb_id_mapping：[%s][%s]" % (tmdb_id, file_name))
-                        media_type = MediaType.MOVIE if media_type == "movie" else MediaType.TV if media_type == "tv" else media_type
-                        file_media_info = self.get_tmdb_info(mtype=media_type,
-                                                             tmdbid=tmdb_id,
-                                                             chinese=chinese,
-                                                             append_to_response=append_to_response)
-                    elif not self.meta.get_meta_data_by_key(media_key):
+                    if not self.meta.get_meta_data_by_key(media_key):
                         # 没有缓存数据
                         file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
                                                              first_media_year=meta_info.year,

--- a/app/media/meta/metavideo.py
+++ b/app/media/meta/metavideo.py
@@ -8,7 +8,6 @@ from app.utils.tokens import Tokens
 from app.utils.types import MediaType
 from app.media.meta.release_groups import ReleaseGroupsMatcher
 from app.media.meta.customization import CustomizationMatcher
-from config import Config
 
 class MetaVideo(MetaBase):
     """
@@ -174,7 +173,7 @@ class MetaVideo(MetaBase):
                 name = None
             elif self.is_in_episode(int(name)) and not self.begin_season:
                 name = None
-        name = Config().get_video_name_mapping(name)
+        # 映射已移到 get_media_info() 识别阶段处理，此处只做清洗
         return name
 
     def __init_name(self, token):

--- a/config.py
+++ b/config.py
@@ -3,7 +3,6 @@ import shutil
 import sys
 import threading
 import ruamel.yaml
-import re
 
 # 种子名/文件名要素分隔字符
 SPLIT_CHARS = r"\.|\s+|\(|\)|\[|]|-|\+|【|】|/|～|;|&|\||#|_|「|」|~"
@@ -102,11 +101,8 @@ class Config(object):
     _config = {}
     _config_path = None
     _user = None
-    _video_name_mapping = {}
-    _video_name_mapping_mtime=0
-    _tmdb_id_mapping = {}
-    _r_tmdb_id_mapping = {}
-    _tmdb_id_mapping_mtime=0
+    _media_mapping = {}
+    _media_mapping_mtime = 0
 
     def __init__(self):
         self._config_path = os.environ.get('NASTOOL_CONFIG')
@@ -114,8 +110,7 @@ class Config(object):
             os.environ['TZ'] = 'Asia/Shanghai'
         self.init_syspath()
         self.init_config()
-        self.init_video_name_mapping()
-        self.init_tmdb_id_mapping()
+        self.init_media_mapping()
 
     def init_config(self):
         try:
@@ -150,133 +145,148 @@ class Config(object):
                 if module_path not in sys.path:
                     sys.path.append(module_path)
 
-    def init_video_name_mapping(self):
-        mapping_config_file = self.get_video_name_mapping_file()
-        self._video_name_mapping={}
+    # ---- media_mapping ----
+
+    @staticmethod
+    def normalize_media_mapping_key(name):
+        if not name:
+            return name
+        return name.replace(' ', '_').lower()
+
+    def get_media_mapping_file(self):
+        file_name = self.get_config("app").get("media_mapping_file")
+        if not file_name:
+            file_name = "/config/media_mapping.yaml"
+        if not os.path.isabs(file_name):
+            file_name = os.path.join(os.path.dirname(self._config_path), file_name)
+        return file_name
+
+    def init_media_mapping(self):
+        mapping_config_file = self.get_media_mapping_file()
+        self._media_mapping = {}
+        self._media_mapping_mtime = 0
         if not os.path.exists(mapping_config_file):
             return
         with open(mapping_config_file, mode='r', encoding='utf-8') as cf:
             try:
-                # 读取配置
-                self._video_name_mapping = ruamel.yaml.YAML().load(cf) or {}
-                self._video_name_mapping_mtime=os.path.getmtime(mapping_config_file)
+                self._media_mapping = ruamel.yaml.YAML().load(cf) or {}
+                self._media_mapping_mtime = os.path.getmtime(mapping_config_file)
             except Exception as e:
                 print("【Config】配置文件 %s 格式出现严重错误！请检查：%s" % (mapping_config_file, str(e)))
-                self._video_name_mapping={}
-        return
+                self._media_mapping = {}
 
-    def check_and_reload_video_name_mapping(self):
-        mapping_config_file = self.get_video_name_mapping_file()
+    def check_and_reload_media_mapping(self):
+        mapping_config_file = self.get_media_mapping_file()
         if not os.path.exists(mapping_config_file):
-            self._video_name_mapping = {}
-            self._video_name_mapping_mtime = 0
+            self._media_mapping = {}
+            self._media_mapping_mtime = 0
             return
         now_mtime = os.path.getmtime(mapping_config_file)
-        if now_mtime > self._video_name_mapping_mtime:
-            self.init_video_name_mapping()
+        if now_mtime > self._media_mapping_mtime:
+            self.init_media_mapping()
 
-    def get_video_name_mapping(self, name):
+    def get_media_mapping(self, name):
         if not name:
-            return name
+            return None
         with lock:
-            self.check_and_reload_video_name_mapping()
-            key_name = name.replace(' ', '_').lower()
-            return self._video_name_mapping.get(key_name, name)
+            self.check_and_reload_media_mapping()
+            key_name = self.normalize_media_mapping_key(name)
+            mapping = self._media_mapping.get(key_name)
+            if not mapping:
+                return None
+            # 返回副本，避免外部修改影响内部存储
+            result = dict(mapping)
+            # tmdbid 统一转为 int
+            if "tmdbid" in result and result["tmdbid"] is not None:
+                try:
+                    result["tmdbid"] = int(result["tmdbid"])
+                except (ValueError, TypeError):
+                    pass
+            return result
 
-    def _save_video_name_mapping(self):
+    def list_media_mapping(self, name=None):
+        with lock:
+            self.check_and_reload_media_mapping()
+            if name:
+                key_name = self.normalize_media_mapping_key(name)
+                if key_name in self._media_mapping:
+                    mapping = dict(self._media_mapping[key_name])
+                    if "tmdbid" in mapping and mapping["tmdbid"] is not None:
+                        try:
+                            mapping["tmdbid"] = int(mapping["tmdbid"])
+                        except (ValueError, TypeError):
+                            pass
+                    return {key_name: mapping}
+                return {}
+            result = {}
+            for k, v in self._media_mapping.items():
+                mapping = dict(v)
+                if "tmdbid" in mapping and mapping["tmdbid"] is not None:
+                    try:
+                        mapping["tmdbid"] = int(mapping["tmdbid"])
+                    except (ValueError, TypeError):
+                        pass
+                result[k] = mapping
+            return result
+
+    def _save_media_mapping(self):
         """内部方法，调用方必须已持有 lock"""
-        mapping_config_file = self.get_video_name_mapping_file()
+        mapping_config_file = self.get_media_mapping_file()
         os.makedirs(os.path.dirname(mapping_config_file), exist_ok=True)
         tmp = mapping_config_file + '.tmp'
         with open(tmp, mode='w', encoding='utf-8') as sf:
-            ruamel.yaml.YAML().dump(self._video_name_mapping, sf)
+            ruamel.yaml.YAML().dump(self._media_mapping, sf)
         os.replace(tmp, mapping_config_file)
-        self._video_name_mapping_mtime = os.path.getmtime(mapping_config_file)
+        self._media_mapping_mtime = os.path.getmtime(mapping_config_file)
 
-    def set_video_name_mapping(self, key, value):
-        if not key or not value:
-            return
+    def set_media_mapping(self, key, value):
+        if not key:
+            return False
+        if not value:
+            return False
+        title = str(value.get("title") or "").strip()
+        media_type = str(value.get("type") or "").strip()
+        tmdbid_raw = value.get("tmdbid")
+        tmdbid = str(tmdbid_raw).strip() if tmdbid_raw not in (None, "") else ""
+        # 校验：tmdbid 存在时必须是数字
+        if tmdbid:
+            try:
+                tmdbid_int = int(tmdbid)
+            except (ValueError, TypeError):
+                return False
+        else:
+            tmdbid_int = None
+        # 校验：tmdbid 存在时 type 必填
+        if tmdbid and not media_type:
+            return False
+        # 校验：没有 tmdbid 时 title 必填
+        if not tmdbid and not title:
+            return False
+        # 校验：type 存在时只能是 movie 或 tv
+        if media_type and media_type not in ("movie", "tv"):
+            return False
         with lock:
-            self.check_and_reload_video_name_mapping()
-            key_name = key.replace(' ', '_').lower()
-            self._video_name_mapping[key_name] = value
-            self._save_video_name_mapping()
+            self.check_and_reload_media_mapping()
+            key_name = self.normalize_media_mapping_key(key)
+            mapping = {}
+            if title:
+                mapping["title"] = title
+            if media_type:
+                mapping["type"] = media_type
+            if tmdbid_int is not None:
+                mapping["tmdbid"] = tmdbid_int
+            self._media_mapping[key_name] = mapping
+            self._save_media_mapping()
+        return True
 
-    def delete_video_name_mapping(self, key):
+    def delete_media_mapping(self, key):
         if not key:
             return
         with lock:
-            self.check_and_reload_video_name_mapping()
-            key_name = key.replace(' ', '_').lower()
-            self._video_name_mapping.pop(key_name, None)
-            self._save_video_name_mapping()
-
-    def list_video_name_mapping(self, name=None):
-        with lock:
-            self.check_and_reload_video_name_mapping()
-            if name:
-                key_name = name.replace(' ', '_').lower()
-                if key_name in self._video_name_mapping:
-                    return {key_name: self._video_name_mapping[key_name]}
-                return {}
-            return dict(self._video_name_mapping)
-
-    def init_tmdb_id_mapping(self):
-        mapping_config_file = self.get_tmdb_id_mapping_file()
-        self._tmdb_id_mapping = {}
-        self._r_tmdb_id_mapping = {}
-        self._tmdb_id_mapping_mtime = 0
-        if not os.path.exists(mapping_config_file):
-            return
-        with open(mapping_config_file, mode='r', encoding='utf-8') as cf:
-            try:
-                # 读取配置
-                for line in cf.readlines():
-                    line = line.strip()
-                    if not line:
-                        continue
-                    # 先检查是否是正则表达式规则
-                    if line.startswith("r:"):
-                        is_regex, video_name, media_type, tmdb_id = line.split(":")
-                        media_type = media_type.strip().lower()
-                        self._r_tmdb_id_mapping[video_name.strip()] = [media_type, tmdb_id.strip()]
-                    else:
-                        # 普通规则使用简单的split
-                        video_name, media_type, tmdb_id = line.split(":")
-                        media_type = media_type.strip().lower()
-                        self._tmdb_id_mapping[video_name.strip()] = [media_type, tmdb_id.strip()]
-                self._tmdb_id_mapping_mtime = os.path.getatime(mapping_config_file)
-            except Exception as e:
-                print("【Config】配置文件 %s 格式出现严重错误！请检查：%s" % (mapping_config_file, str(e)))
-                self._tmdb_id_mapping = {}
-                self._r_tmdb_id_mapping = {}
-                self._tmdb_id_mapping_mtime = 0
-        return
-
-    def check_and_reload_tmdb_id_mapping(self):
-        mapping_config_file = self.get_tmdb_id_mapping_file()
-        if not os.path.exists(mapping_config_file):
-            self._tmdb_id_mapping = {}
-            self._r_tmdb_id_mapping = {}
-            self._tmdb_id_mapping_mtime = 0
-            return
-        now_mtime = os.path.getatime(mapping_config_file)
-        if now_mtime > self._tmdb_id_mapping_mtime:
-            self.init_tmdb_id_mapping()
-
-    def get_tmdb_id_mapping(self, name):
-        if not name:
-            return name
-        self.check_and_reload_tmdb_id_mapping()
-        # 先尝试精确匹配
-        result = self._tmdb_id_mapping.get(name)
-        if result:
-            return result
-        # 如果精确匹配失败，尝试正则表达式匹配
-        for regex, value in self._r_tmdb_id_mapping.items():
-            if re.match(regex, name):
-                return value
-        return 0
+            self.check_and_reload_media_mapping()
+            key_name = self.normalize_media_mapping_key(key)
+            self._media_mapping.pop(key_name, None)
+            self._save_media_mapping()
 
     @property
     def current_user(self):
@@ -339,20 +349,6 @@ class Config(object):
         global RMT_FAVTYPE
         if favtype:
             RMT_FAVTYPE = favtype
-
-    def get_video_name_mapping_file(self):
-        file_name = self.get_config("app").get("video_name_mapping_file")
-        if not file_name:
-            file_name = "/config/video_name_mapping.yaml"
-        if not os.path.isabs(file_name):
-            file_name = os.path.join(os.path.dirname(self._config_path), file_name)
-        return file_name
-
-    def get_tmdb_id_mapping_file(self):
-        file_name = self.get_config("app").get("tmdb_id_mapping_file")
-        if not file_name:
-            file_name = "/config/tmdb_id_mapping.conf"
-        return file_name
 
     def get_tmdbapi_url(self):
         return f"https://{self.get_config('app').get('tmdb_domain') or TMDB_API_DOMAINS[0]}/3"

--- a/docs/plan/006-media-mapping-unification.md
+++ b/docs/plan/006-media-mapping-unification.md
@@ -1010,3 +1010,31 @@ tmdbid 存在时 type 必填
 - 文件管理页“媒体映射”可同时配置 `title`、`type`、`tmdbid`。
 - UI 和后端都强制执行：有 `tmdbid` 时 `type` 必填。
 - `Climax.S01E01` 到 `S01E10` 只需配置一次 `climax` 即可全部命中同一个 TMDB ID。
+
+## 十一、实施记录
+
+### 已完成变更
+
+| 文件 | 变更 |
+|---|---|
+| config.py | 新增 media_mapping 配置层（init/get/set/delete/list/save）；删除 tmdb_id_mapping 全部代码 |
+| config/config.yaml | 新增 media_mapping_file 配置项 |
+| app/media/media.py | 新增 __apply_media_mapping()；get_media_info/get_media_info_on_files 使用 media_mapping 替代 tmdb_id_mapping |
+| app/media/meta/metavideo.py | 从 __fix_name() 移除 get_video_name_mapping 调用 |
+| web/action.py | 替换为 get_media_mappings/set_media_mapping/delete_media_mapping |
+| web/templates/rename/mediafile.html | 按钮改为"媒体映射"；弹窗支持 title/type/tmdbid |
+| scripts/migrate_video_name_mapping.py | 新增迁移脚本 |
+| tests/test_media_mapping.py | Config 层 18 个单元测试 |
+| tests/test_media_mapping_migration.py | 迁移脚本 9 个单元测试 |
+
+### 迁移方式
+```bash
+# 预览迁移结果
+python scripts/migrate_video_name_mapping.py --source video_name_mapping.yaml --target media_mapping.yaml --dry-run
+
+# 执行迁移
+python scripts/migrate_video_name_mapping.py --source video_name_mapping.yaml --target media_mapping.yaml --overwrite
+```
+
+### 已知限制
+- MetaVideo 的 `_name_nostring_re` 中 IMAX 正则无 `\b` 边界，会将 `Climax` 清洗为 `Cl`。这是已有行为，不影响映射功能正确性，但映射键需使用清洗后的名称（如 `cl` 而非 `climax`）。

--- a/scripts/migrate_video_name_mapping.py
+++ b/scripts/migrate_video_name_mapping.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Migration script: convert video_name_mapping.yaml to media_mapping.yaml.
+
+Usage:
+    python scripts/migrate_video_name_mapping.py [--source PATH] [--target PATH] [--overwrite] [--dry-run]
+
+Each `key: value` entry in the source file is converted to `key: {title: value}`.
+"""
+
+import argparse
+import os
+import sys
+import tempfile
+
+import yaml
+
+
+def migrate(source_path, target_path, overwrite=False, dry_run=False):
+    # Source file must exist
+    if not os.path.exists(source_path):
+        print(f"Error: source file not found: {source_path}", file=sys.stderr)
+        return 1
+
+    with open(source_path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+
+    # Empty source: empty dict, None, or empty file
+    if not raw:
+        print(f"Source file is empty, nothing to migrate: {source_path}")
+        return 0
+
+    if not isinstance(raw, dict):
+        print(f"Error: source file is not a YAML dict: {source_path}", file=sys.stderr)
+        return 1
+
+    # Convert key: value -> key: {title: value}
+    migrated = {}
+    for key, value in raw.items():
+        migrated[key] = {"title": value}
+
+    output_yaml = yaml.dump(migrated, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+    if dry_run:
+        print(output_yaml, end="")
+        return 0
+
+    # Target file exists check
+    if os.path.exists(target_path) and not overwrite:
+        print(
+            f"Error: target file already exists: {target_path}\n"
+            f"Use --overwrite to replace it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Atomic write: write to temp file then os.replace()
+    target_dir = os.path.dirname(target_path)
+    if target_dir:
+        os.makedirs(target_dir, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(dir=target_dir, suffix=".yaml")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(output_yaml)
+        os.replace(tmp_path, target_path)
+    except Exception:
+        # Clean up temp file on failure
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    print(f"Migrated {len(migrated)} entries: {source_path} -> {target_path}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate video_name_mapping.yaml to media_mapping.yaml"
+    )
+    parser.add_argument(
+        "--source",
+        default="/config/video_name_mapping.yaml",
+        help="Source video_name_mapping.yaml path (default: /config/video_name_mapping.yaml)",
+    )
+    parser.add_argument(
+        "--target",
+        default="/config/media_mapping.yaml",
+        help="Target media_mapping.yaml path (default: /config/media_mapping.yaml)",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite target file if it already exists",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print migrated YAML to stdout without writing file",
+    )
+    args = parser.parse_args()
+    sys.exit(migrate(args.source, args.target, overwrite=args.overwrite, dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_media_mapping.py
+++ b/tests/test_media_mapping.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+# 在导入 Config 前设置必要的环境变量
+_test_dir = tempfile.mkdtemp(prefix="media_mapping_test_root_")
+_test_config = os.path.join(_test_dir, "config.yaml")
+if not os.path.exists(_test_config):
+    import shutil as _shutil
+    _tpl = os.path.join(os.path.dirname(__file__), "..", "config", "config.yaml")
+    _shutil.copy(_tpl, _test_config)
+os.environ.setdefault("NASTOOL_CONFIG", _test_config)
+
+from config import Config
+
+
+class MediaMappingTest(unittest.TestCase):
+    """Config 媒体映射接口单元测试"""
+
+    def setUp(self):
+        # 使用临时目录避免污染真实配置
+        self._tmpdir = tempfile.mkdtemp(prefix="media_mapping_test_")
+        self._mapping_file = os.path.join(self._tmpdir, "media_mapping.yaml")
+
+        # 保存原始状态
+        cfg = Config()
+        self._orig_get_file = cfg.get_media_mapping_file
+        self._orig_mapping = dict(cfg._media_mapping)
+        self._orig_mtime = cfg._media_mapping_mtime
+
+        # 替换 get_media_mapping_file 指向临时文件
+        cfg.get_media_mapping_file = lambda: self._mapping_file
+
+        # 重置内存状态
+        cfg._media_mapping = {}
+        cfg._media_mapping_mtime = 0
+
+    def tearDown(self):
+        # 恢复原始状态
+        cfg = Config()
+        cfg.get_media_mapping_file = self._orig_get_file
+        cfg._media_mapping = self._orig_mapping
+        cfg._media_mapping_mtime = self._orig_mtime
+
+        # 清理临时目录
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_normalize_media_mapping_key(self):
+        cfg = Config()
+        # 空值返回原值
+        self.assertEqual(cfg.normalize_media_mapping_key(""), "")
+        self.assertIsNone(cfg.normalize_media_mapping_key(None))
+        # 空格转下划线 + 小写
+        self.assertEqual(cfg.normalize_media_mapping_key("The Long Season"), "the_long_season")
+        self.assertEqual(cfg.normalize_media_mapping_key("Climax"), "climax")
+        self.assertEqual(cfg.normalize_media_mapping_key("漫长的季节"), "漫长的季节")
+
+    def test_get_media_mapping_key_normalization(self):
+        """get_media_mapping 应当通过规范化 key 命中"""
+        cfg = Config()
+        # 用未规范化的 key 保存
+        result = cfg.set_media_mapping("The Long Season", {"title": "漫长的季节"})
+        self.assertTrue(result)
+        # 用不同大小写/空格风格的名称都应命中
+        self.assertEqual(cfg.get_media_mapping("The Long Season"), {"title": "漫长的季节"})
+        self.assertEqual(cfg.get_media_mapping("the long season"), {"title": "漫长的季节"})
+        self.assertEqual(cfg.get_media_mapping("THE LONG SEASON"), {"title": "漫长的季节"})
+        self.assertEqual(cfg.get_media_mapping("the_long_season"), {"title": "漫长的季节"})
+
+    def test_save_title_only(self):
+        """只保存 title 应成功"""
+        cfg = Config()
+        result = cfg.set_media_mapping("the_long_season", {"title": "漫长的季节"})
+        self.assertTrue(result)
+        mapping = cfg.get_media_mapping("the_long_season")
+        self.assertEqual(mapping, {"title": "漫长的季节"})
+        # 落盘后不应包含空值字段
+        self.assertNotIn("type", mapping)
+        self.assertNotIn("tmdbid", mapping)
+
+    def test_save_title_and_type(self):
+        """保存 title + type 应成功"""
+        cfg = Config()
+        result = cfg.set_media_mapping("test_movie", {"title": "测试电影", "type": "movie"})
+        self.assertTrue(result)
+        mapping = cfg.get_media_mapping("test_movie")
+        self.assertEqual(mapping, {"title": "测试电影", "type": "movie"})
+
+    def test_save_tmdbid_and_type(self):
+        """保存 tmdbid + type 应成功，tmdbid 统一为 int"""
+        cfg = Config()
+        # string tmdbid
+        result = cfg.set_media_mapping("climax", {"title": "Climax", "type": "tv", "tmdbid": "241860"})
+        self.assertTrue(result)
+        mapping = cfg.get_media_mapping("climax")
+        self.assertEqual(mapping["title"], "Climax")
+        self.assertEqual(mapping["type"], "tv")
+        self.assertEqual(mapping["tmdbid"], 241860)
+        self.assertIsInstance(mapping["tmdbid"], int)
+
+        # int tmdbid
+        result = cfg.set_media_mapping("climax2", {"type": "tv", "tmdbid": 241861})
+        self.assertTrue(result)
+        mapping = cfg.get_media_mapping("climax2")
+        self.assertEqual(mapping["tmdbid"], 241861)
+        self.assertIsInstance(mapping["tmdbid"], int)
+
+    def test_save_tmdbid_without_type_fails(self):
+        """保存 tmdbid 但缺 type 应失败"""
+        cfg = Config()
+        result = cfg.set_media_mapping("climax", {"title": "Climax", "tmdbid": "241860"})
+        self.assertFalse(result)
+        # 失败后不应有数据写入
+        self.assertIsNone(cfg.get_media_mapping("climax"))
+
+    def test_save_empty_title_and_tmdbid_fails(self):
+        """同时空 title 和空 tmdbid 应失败"""
+        cfg = Config()
+        result = cfg.set_media_mapping("key", {"title": "", "tmdbid": ""})
+        self.assertFalse(result)
+        result = cfg.set_media_mapping("key", {"type": "tv"})
+        self.assertFalse(result)
+        result = cfg.set_media_mapping("key", {})
+        self.assertFalse(result)
+        self.assertIsNone(cfg.get_media_mapping("key"))
+
+    def test_save_invalid_type_fails(self):
+        """非 movie/tv 的 type 应失败"""
+        cfg = Config()
+        result = cfg.set_media_mapping("key", {"title": "Test", "type": "anime"})
+        self.assertFalse(result)
+        self.assertIsNone(cfg.get_media_mapping("key"))
+
+    def test_save_invalid_tmdbid_fails(self):
+        """非数字 tmdbid 应失败"""
+        cfg = Config()
+        result = cfg.set_media_mapping("key", {"title": "Test", "type": "tv", "tmdbid": "abc"})
+        self.assertFalse(result)
+        self.assertIsNone(cfg.get_media_mapping("key"))
+
+    def test_save_empty_key_fails(self):
+        """空 key 应失败"""
+        cfg = Config()
+        result = cfg.set_media_mapping("", {"title": "Test"})
+        self.assertFalse(result)
+        result = cfg.set_media_mapping(None, {"title": "Test"})
+        self.assertFalse(result)
+
+    def test_delete_mapping(self):
+        """删除 mapping 后不应再命中"""
+        cfg = Config()
+        cfg.set_media_mapping("the_long_season", {"title": "漫长的季节"})
+        self.assertIsNotNone(cfg.get_media_mapping("the_long_season"))
+        cfg.delete_media_mapping("the_long_season")
+        self.assertIsNone(cfg.get_media_mapping("the_long_season"))
+
+    def test_delete_with_key_normalization(self):
+        """删除时也按规范化 key"""
+        cfg = Config()
+        cfg.set_media_mapping("The Long Season", {"title": "漫长的季节"})
+        cfg.delete_media_mapping("the long season")
+        self.assertIsNone(cfg.get_media_mapping("The Long Season"))
+
+    def test_get_media_mapping_returns_copy(self):
+        """get_media_mapping 返回的 dict 应为副本，外部修改不影响内部"""
+        cfg = Config()
+        cfg.set_media_mapping("climax", {"title": "Climax", "type": "tv", "tmdbid": "241860"})
+        mapping = cfg.get_media_mapping("climax")
+        mapping["title"] = "Modified"
+        # 再次读取应是原始值
+        mapping2 = cfg.get_media_mapping("climax")
+        self.assertEqual(mapping2["title"], "Climax")
+
+    def test_list_media_mapping(self):
+        """list 返回全部或单个映射"""
+        cfg = Config()
+        cfg.set_media_mapping("climax", {"title": "Climax", "type": "tv", "tmdbid": "241860"})
+        cfg.set_media_mapping("the_long_season", {"title": "漫长的季节"})
+
+        all_mappings = cfg.list_media_mapping()
+        self.assertEqual(len(all_mappings), 2)
+        self.assertIn("climax", all_mappings)
+        self.assertIn("the_long_season", all_mappings)
+        # tmdbid 应为 int
+        self.assertEqual(all_mappings["climax"]["tmdbid"], 241860)
+
+        single = cfg.list_media_mapping("Climax")
+        self.assertEqual(len(single), 1)
+        self.assertEqual(single["climax"]["title"], "Climax")
+
+        # 不存在时返回空 dict
+        empty = cfg.list_media_mapping("not_exist")
+        self.assertEqual(empty, {})
+
+    def test_tmdbid_int_in_yaml(self):
+        """YAML 中 tmdbid 写 int 也应工作"""
+        cfg = Config()
+        # 写入 YAML
+        import ruamel.yaml
+        with open(self._mapping_file, mode='w', encoding='utf-8') as sf:
+            ruamel.yaml.YAML().dump({
+                "climax": {"title": "Climax", "type": "tv", "tmdbid": 241860}
+            }, sf)
+        # 强制重新加载
+        cfg._media_mapping = {}
+        cfg._media_mapping_mtime = 0
+        mapping = cfg.get_media_mapping("climax")
+        self.assertEqual(mapping["tmdbid"], 241860)
+        self.assertIsInstance(mapping["tmdbid"], int)
+
+    def test_tmdbid_string_in_yaml(self):
+        """YAML 中 tmdbid 写 string 时运行时统一转为 int"""
+        cfg = Config()
+        import ruamel.yaml
+        with open(self._mapping_file, mode='w', encoding='utf-8') as sf:
+            ruamel.yaml.YAML().dump({
+                "climax": {"title": "Climax", "type": "tv", "tmdbid": "241860"}
+            }, sf)
+        cfg._media_mapping = {}
+        cfg._media_mapping_mtime = 0
+        mapping = cfg.get_media_mapping("climax")
+        self.assertEqual(mapping["tmdbid"], 241860)
+        self.assertIsInstance(mapping["tmdbid"], int)
+
+    def test_check_and_reload_on_file_removal(self):
+        """文件被删除时内存映射应清空"""
+        cfg = Config()
+        cfg.set_media_mapping("climax", {"title": "Climax", "type": "tv", "tmdbid": "241860"})
+        self.assertIsNotNone(cfg.get_media_mapping("climax"))
+        # 删除文件
+        os.remove(self._mapping_file)
+        # 下次访问应清空
+        self.assertIsNone(cfg.get_media_mapping("climax"))
+
+    def test_get_media_mapping_empty_name(self):
+        """空 name 返回 None"""
+        cfg = Config()
+        self.assertIsNone(cfg.get_media_mapping(""))
+        self.assertIsNone(cfg.get_media_mapping(None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_media_mapping_migration.py
+++ b/tests/test_media_mapping_migration.py
@@ -1,0 +1,148 @@
+"""Tests for migrate_video_name_mapping.py"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import yaml
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "migrate_video_name_mapping.py")
+
+
+def run_migrate(*args, stdin=None):
+    """Run the migration script and return (returncode, stdout, stderr)."""
+    cmd = [sys.executable, SCRIPT] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=os.path.dirname(__file__))
+    return result.returncode, result.stdout, result.stderr
+
+
+class TestBasicConversion:
+    """Basic conversion: key: value -> key: {title: value}"""
+
+    def test_simple_entry(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text("the_long_season: 漫长的季节\n", encoding="utf-8")
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst))
+        assert rc == 0
+        assert dst.exists()
+
+        with open(dst, "r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
+        assert result == {"the_long_season": {"title": "漫长的季节"}}
+
+    def test_multiple_entries(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text(
+            "the_long_season: 漫长的季节\nclimax: Climax\n",
+            encoding="utf-8",
+        )
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst))
+        assert rc == 0
+
+        with open(dst, "r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
+        assert result == {
+            "the_long_season": {"title": "漫长的季节"},
+            "climax": {"title": "Climax"},
+        }
+
+
+class TestTargetExistsNoOverwrite:
+    """Target exists without --overwrite fails"""
+
+    def test_fails_when_target_exists(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text("the_long_season: 漫长的季节\n", encoding="utf-8")
+        dst.write_text("existing: data\n", encoding="utf-8")
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst))
+        assert rc != 0
+        assert "already exists" in err
+
+        # Target should not be modified
+        assert dst.read_text(encoding="utf-8") == "existing: data\n"
+
+
+class TestTargetExistsWithOverwrite:
+    """Target exists with --overwrite succeeds"""
+
+    def test_overwrites_when_flag_set(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text("the_long_season: 漫长的季节\n", encoding="utf-8")
+        dst.write_text("existing: data\n", encoding="utf-8")
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst), "--overwrite")
+        assert rc == 0
+
+        with open(dst, "r", encoding="utf-8") as f:
+            result = yaml.safe_load(f)
+        assert result == {"the_long_season": {"title": "漫长的季节"}}
+
+
+class TestDryRun:
+    """--dry-run outputs YAML but doesn't write file"""
+
+    def test_dry_run_no_file_written(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text("the_long_season: 漫长的季节\n", encoding="utf-8")
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst), "--dry-run")
+        assert rc == 0
+        assert not dst.exists()
+
+        # stdout should contain valid YAML
+        result = yaml.safe_load(out)
+        assert result == {"the_long_season": {"title": "漫长的季节"}}
+
+
+class TestEmptySource:
+    """Empty source file"""
+
+    def test_empty_dict(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text("{}\n", encoding="utf-8")
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst))
+        assert rc == 0
+        assert not dst.exists()
+        assert "empty" in out.lower()
+
+    def test_empty_file(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text("", encoding="utf-8")
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst))
+        assert rc == 0
+        assert not dst.exists()
+
+    def test_whitespace_only_file(self, tmp_path):
+        src = tmp_path / "source.yaml"
+        dst = tmp_path / "target.yaml"
+        src.write_text("  \n  \n", encoding="utf-8")
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst))
+        assert rc == 0
+        assert not dst.exists()
+
+
+class TestSourceNotFound:
+    """Source file not found"""
+
+    def test_nonexistent_source(self, tmp_path):
+        src = tmp_path / "nonexistent.yaml"
+        dst = tmp_path / "target.yaml"
+
+        rc, out, err = run_migrate("--source", str(src), "--target", str(dst))
+        assert rc != 0
+        assert "not found" in err.lower()

--- a/web/action.py
+++ b/web/action.py
@@ -104,9 +104,9 @@ class WebAction:
             "brushtask_detail": self.__brushtask_detail,
             "update_brushtask_state": self.__update_brushtask_state,
             "name_test": self.__name_test,
-            "get_video_name_mappings": self.__get_video_name_mappings,
-            "set_video_name_mapping": self.__set_video_name_mapping,
-            "delete_video_name_mapping": self.__delete_video_name_mapping,
+            "get_media_mappings": self.__get_media_mappings,
+            "set_media_mapping": self.__set_media_mapping,
+            "delete_media_mapping": self.__delete_media_mapping,
             "rule_test": self.__rule_test,
             "net_test": self.__net_test,
             "add_filtergroup": self.__add_filtergroup,
@@ -5140,28 +5140,47 @@ class WebAction:
         return {"code": 0, "result": result}
 
     @staticmethod
-    def __get_video_name_mappings(data):
-        result = Config().list_video_name_mapping(data.get("name"))
+    def __get_media_mappings(data):
+        result = Config().list_media_mapping(data.get("name"))
         return {"code": 0, "data": result}
 
     @staticmethod
-    def __set_video_name_mapping(data):
-        key, value = data.get("key"), data.get("value")
-        if not key or not value:
-            return {"code": 1, "msg": "原始名称和映射名称不能为空"}
+    def __set_media_mapping(data):
+        key = data.get("key")
+        title = data.get("title")
+        media_type = data.get("type")
+        tmdbid = data.get("tmdbid")
+        if not key:
+            return {"code": 1, "msg": "原始名称不能为空"}
         try:
-            Config().set_video_name_mapping(key, value)
+            result = Config().set_media_mapping(key, {
+                "title": title,
+                "type": media_type,
+                "tmdbid": tmdbid
+            })
+            if not result:
+                return {"code": 1, "msg": "保存失败：填写TMDB ID时必须选择媒体类型，未填写TMDB ID时必须填写映射名称"}
             return {"code": 0, "msg": "保存成功"}
         except Exception as e:
             return {"code": 1, "msg": str(e)}
 
     @staticmethod
-    def __delete_video_name_mapping(data):
+    def __delete_media_mapping(data):
         key = data.get("key")
         if not key:
             return {"code": 1, "msg": "原始名称不能为空"}
         try:
-            Config().delete_video_name_mapping(key)
+            Config().delete_media_mapping(key)
+            # 清除对应的 meta cache，避免重新识别返回旧结果
+            from app.media.media import Media
+            media_key = Config().normalize_media_mapping_key(key)
+            meta = Media().meta
+            if meta:
+                for cache_key in list(meta._meta_data.keys()):
+                    if cache_key.lower().replace(' ', '_') == media_key:
+                        meta.delete_meta_data(cache_key)
+                        meta.save_meta_data()
+                        break
             return {"code": 0, "msg": "删除成功"}
         except Exception as e:
             return {"code": 1, "msg": str(e)}

--- a/web/templates/rename/mediafile.html
+++ b/web/templates/rename/mediafile.html
@@ -87,10 +87,6 @@
         <div class="mb-3" id="media_mapping_type_group">
           <label class="form-label">媒体类型</label>
           <div class="form-check form-check-inline">
-            <input class="form-check-input" type="radio" name="media_mapping_type" id="media_mapping_type_auto" value="">
-            <label class="form-check-label" for="media_mapping_type_auto">自动</label>
-          </div>
-          <div class="form-check form-check-inline">
             <input class="form-check-input" type="radio" name="media_mapping_type" id="media_mapping_type_movie" value="movie">
             <label class="form-check-label" for="media_mapping_type_movie">电影</label>
           </div>

--- a/web/templates/rename/mediafile.html
+++ b/web/templates/rename/mediafile.html
@@ -81,16 +81,23 @@
           <input type="text" id="media_mapping_title" class="form-control" placeholder="无 TMDB ID 时必填">
         </div>
         <div class="mb-3">
-          <label class="form-label">媒体类型</label>
-          <select id="media_mapping_type" class="form-select">
-            <option value="">自动</option>
-            <option value="movie">电影</option>
-            <option value="tv">电视剧</option>
-          </select>
-        </div>
-        <div class="mb-3">
           <label class="form-label">TMDB ID</label>
           <input type="text" id="media_mapping_tmdbid" class="form-control" placeholder="纯数字，填写时需选择媒体类型">
+        </div>
+        <div class="mb-3" id="media_mapping_type_group">
+          <label class="form-label">媒体类型</label>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="media_mapping_type" id="media_mapping_type_auto" value="">
+            <label class="form-check-label" for="media_mapping_type_auto">自动</label>
+          </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="media_mapping_type" id="media_mapping_type_movie" value="movie">
+            <label class="form-check-label" for="media_mapping_type_movie">电影</label>
+          </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="media_mapping_type" id="media_mapping_type_tv" value="tv">
+            <label class="form-check-label" for="media_mapping_type_tv">电视剧</label>
+          </div>
         </div>
         <!-- 保存 filename 和 filepos，用于保存后自动重新识别 -->
         <input type="hidden" id="media_mapping_filename_hidden">
@@ -195,7 +202,7 @@
       $("#media_mapping_filepos_hidden").val(id);
       $("#media_mapping_filename").val(name);
       $("#media_mapping_title").removeClass("is-invalid");
-      $("#media_mapping_type").removeClass("is-invalid");
+      $("#media_mapping_type_group input").removeClass("is-invalid");
       $("#media_mapping_tmdbid").removeClass("is-invalid");
 
       // 自行请求识别结果（含 raw_name）
@@ -203,7 +210,7 @@
           if (ret.code !== 0 || !ret.data || ret.data.name === "无法识别") {
               $("#media_mapping_source").val("无法识别");
               $("#media_mapping_title").val("").prop("disabled", true);
-              $("#media_mapping_type").val("").prop("disabled", true);
+              $("#media_mapping_type_group input").prop('checked', false).prop('disabled', true);
               $("#media_mapping_tmdbid").val("").prop("disabled", true);
               $("#media_mapping_save_btn").addClass("disabled");
               $("#media_mapping_delete_btn").addClass("d-none");
@@ -214,7 +221,7 @@
           let raw_name = ret.data.raw_name || ret.data.name;
           $("#media_mapping_source").val(raw_name);
           $("#media_mapping_title").prop("disabled", false);
-          $("#media_mapping_type").prop("disabled", false);
+          $("#media_mapping_type_group input").prop('disabled', false);
           $("#media_mapping_tmdbid").prop("disabled", false);
           $("#media_mapping_save_btn").removeClass("disabled");
 
@@ -231,12 +238,12 @@
               if (ret2.code === 0 && ret2.data && Object.keys(ret2.data).length > 0) {
                   let mapping = Object.values(ret2.data)[0] || {};
                   $("#media_mapping_title").val(mapping.title || "");
-                  $("#media_mapping_type").val(mapping.type || detected_type);
+                  $("#media_mapping_type_group input[value='" + (mapping.type || detected_type) + "']").prop('checked', true);
                   $("#media_mapping_tmdbid").val(mapping.tmdbid != null ? mapping.tmdbid : "");
                   $("#media_mapping_delete_btn").removeClass("d-none");
               } else {
                   $("#media_mapping_title").val("");
-                  $("#media_mapping_type").val(detected_type);
+                  $("#media_mapping_type_group input[value='" + detected_type + "']").prop('checked', true);
                   $("#media_mapping_tmdbid").val("");
                   $("#media_mapping_delete_btn").addClass("d-none");
               }
@@ -249,13 +256,13 @@
   function save_media_mapping() {
       let raw_name = $("#media_mapping_source").val();
       let title = $("#media_mapping_title").val().trim();
-      let media_type = $("#media_mapping_type").val();
+      let media_type = $("#media_mapping_type_group input:checked").val() || "";
       let tmdbid = $("#media_mapping_tmdbid").val().trim();
       let filename = $("#media_mapping_filename_hidden").val();
       let filepos = $("#media_mapping_filepos_hidden").val();
 
       $("#media_mapping_title").removeClass("is-invalid");
-      $("#media_mapping_type").removeClass("is-invalid");
+      $("#media_mapping_type_group input").removeClass("is-invalid");
       $("#media_mapping_tmdbid").removeClass("is-invalid");
 
       // 前端校验：TMDB ID 必须是纯数字
@@ -266,7 +273,7 @@
       }
       // 前端校验：填写 TMDB ID 时必须选择媒体类型
       if (tmdbid && !media_type) {
-          $("#media_mapping_type").addClass("is-invalid");
+          $("#media_mapping_type_group input").addClass("is-invalid");
           show_fail_modal("填写 TMDB ID 时必须选择媒体类型！");
           return;
       }

--- a/web/templates/rename/mediafile.html
+++ b/web/templates/rename/mediafile.html
@@ -59,36 +59,47 @@
     </div>
   </div>
 </div>
-<div class="modal modal-blur fade" id="modal-name-mapping" tabindex="-1" role="dialog" aria-hidden="true"
+<div class="modal modal-blur fade" id="modal-media-mapping" tabindex="-1" role="dialog" aria-hidden="true"
      data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">名称映射配置</h5>
+        <h5 class="modal-title">媒体映射配置</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <div class="mb-3">
           <label class="form-label">文件名称</label>
-          <input type="text" id="name_mapping_filename" class="form-control" readonly>
+          <input type="text" id="media_mapping_filename" class="form-control" readonly>
         </div>
         <div class="mb-3">
           <label class="form-label">原始名称</label>
-          <input type="text" id="name_mapping_source" class="form-control" readonly>
+          <input type="text" id="media_mapping_source" class="form-control" readonly>
         </div>
         <div class="mb-3">
-          <label class="form-label required">映射名称</label>
-          <input type="text" id="name_mapping_target" class="form-control" placeholder="输入映射后的名称">
+          <label class="form-label">映射名称</label>
+          <input type="text" id="media_mapping_title" class="form-control" placeholder="无 TMDB ID 时必填">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">媒体类型</label>
+          <select id="media_mapping_type" class="form-select">
+            <option value="">自动</option>
+            <option value="movie">电影</option>
+            <option value="tv">电视剧</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">TMDB ID</label>
+          <input type="text" id="media_mapping_tmdbid" class="form-control" placeholder="纯数字，填写时需选择媒体类型">
         </div>
         <!-- 保存 filename 和 filepos，用于保存后自动重新识别 -->
-        <input type="hidden" id="name_mapping_filename_hidden">
-        <input type="hidden" id="name_mapping_filepos_hidden">
-        <input type="hidden" id="name_mapping_has_existing" value="0">
+        <input type="hidden" id="media_mapping_filename_hidden">
+        <input type="hidden" id="media_mapping_filepos_hidden">
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-link me-auto" data-bs-dismiss="modal">取消</button>
-        <a id="name_mapping_delete_btn" href="javascript:delete_name_mapping()" class="btn btn-danger d-none">删除映射</a>
-        <a id="name_mapping_save_btn" href="javascript:save_name_mapping()" class="btn btn-primary">保存映射</a>
+        <a id="media_mapping_delete_btn" href="javascript:delete_media_mapping()" class="btn btn-danger d-none">删除映射</a>
+        <a id="media_mapping_save_btn" href="javascript:save_media_mapping()" class="btn btn-primary">保存映射</a>
       </div>
     </div>
   </div>
@@ -177,63 +188,103 @@
     }
   }
 
-  // 显示名称映射弹窗
-  function show_name_mapping_modal(name, id) {
+  // 显示媒体映射弹窗
+  function show_media_mapping_modal(name, id) {
       // 保存 filename 和 filepos，供 save/delete 后自动重新识别
-      $("#name_mapping_filename_hidden").val(name);
-      $("#name_mapping_filepos_hidden").val(id);
-      $("#name_mapping_filename").val(name);
-      $("#name_mapping_target").removeClass("is-invalid");
+      $("#media_mapping_filename_hidden").val(name);
+      $("#media_mapping_filepos_hidden").val(id);
+      $("#media_mapping_filename").val(name);
+      $("#media_mapping_title").removeClass("is-invalid");
+      $("#media_mapping_type").removeClass("is-invalid");
+      $("#media_mapping_tmdbid").removeClass("is-invalid");
 
       // 自行请求识别结果（含 raw_name）
       ajax_post("name_test", {"name": name}, function(ret) {
           if (ret.code !== 0 || !ret.data || ret.data.name === "无法识别") {
-              $("#name_mapping_source").val("无法识别");
-              $("#name_mapping_target").val("").prop("disabled", true);
-              $("#name_mapping_save_btn").addClass("disabled");
-              $("#name_mapping_delete_btn").addClass("d-none");
-              $("#modal-name-mapping").modal('show');
+              $("#media_mapping_source").val("无法识别");
+              $("#media_mapping_title").val("").prop("disabled", true);
+              $("#media_mapping_type").val("").prop("disabled", true);
+              $("#media_mapping_tmdbid").val("").prop("disabled", true);
+              $("#media_mapping_save_btn").addClass("disabled");
+              $("#media_mapping_delete_btn").addClass("d-none");
+              $("#modal-media-mapping").modal('show');
               return;
           }
 
           let raw_name = ret.data.raw_name || ret.data.name;
-          $("#name_mapping_source").val(raw_name);
-          $("#name_mapping_target").prop("disabled", false);
-          $("#name_mapping_save_btn").removeClass("disabled");
+          $("#media_mapping_source").val(raw_name);
+          $("#media_mapping_title").prop("disabled", false);
+          $("#media_mapping_type").prop("disabled", false);
+          $("#media_mapping_tmdbid").prop("disabled", false);
+          $("#media_mapping_save_btn").removeClass("disabled");
+
+          // 识别结果的 type 映射到 select 值
+          let detected_type = "";
+          if (ret.data.type === "电影") {
+              detected_type = "movie";
+          } else if (ret.data.type === "电视剧" || ret.data.type === "动漫") {
+              detected_type = "tv";
+          }
 
           // 查询已有映射
-          ajax_post("get_video_name_mappings", {name: raw_name}, function(ret2) {
+          ajax_post("get_media_mappings", {name: raw_name}, function(ret2) {
               if (ret2.code === 0 && ret2.data && Object.keys(ret2.data).length > 0) {
-                  let mapped_value = Object.values(ret2.data)[0];
-                  $("#name_mapping_target").val(mapped_value);
-                  $("#name_mapping_delete_btn").removeClass("d-none");
-                  $("#name_mapping_has_existing").val("1");
+                  let mapping = Object.values(ret2.data)[0] || {};
+                  $("#media_mapping_title").val(mapping.title || "");
+                  $("#media_mapping_type").val(mapping.type || detected_type);
+                  $("#media_mapping_tmdbid").val(mapping.tmdbid != null ? mapping.tmdbid : "");
+                  $("#media_mapping_delete_btn").removeClass("d-none");
               } else {
-                  $("#name_mapping_target").val("");
-                  $("#name_mapping_delete_btn").addClass("d-none");
-                  $("#name_mapping_has_existing").val("0");
+                  $("#media_mapping_title").val("");
+                  $("#media_mapping_type").val(detected_type);
+                  $("#media_mapping_tmdbid").val("");
+                  $("#media_mapping_delete_btn").addClass("d-none");
               }
-              $("#modal-name-mapping").modal('show');
+              $("#modal-media-mapping").modal('show');
           });
       });
   }
 
-  // 保存名称映射
-  function save_name_mapping() {
-      let raw_name = $("#name_mapping_source").val();
-      let target = $("#name_mapping_target").val();
-      let filename = $("#name_mapping_filename_hidden").val();
-      let filepos = $("#name_mapping_filepos_hidden").val();
+  // 保存媒体映射
+  function save_media_mapping() {
+      let raw_name = $("#media_mapping_source").val();
+      let title = $("#media_mapping_title").val().trim();
+      let media_type = $("#media_mapping_type").val();
+      let tmdbid = $("#media_mapping_tmdbid").val().trim();
+      let filename = $("#media_mapping_filename_hidden").val();
+      let filepos = $("#media_mapping_filepos_hidden").val();
 
-      if (!target) {
-          $("#name_mapping_target").addClass("is-invalid");
+      $("#media_mapping_title").removeClass("is-invalid");
+      $("#media_mapping_type").removeClass("is-invalid");
+      $("#media_mapping_tmdbid").removeClass("is-invalid");
+
+      // 前端校验：TMDB ID 必须是纯数字
+      if (tmdbid && !/^\d+$/.test(tmdbid)) {
+          $("#media_mapping_tmdbid").addClass("is-invalid");
+          show_fail_modal("TMDB ID 必须是数字！");
           return;
       }
-      $("#name_mapping_target").removeClass("is-invalid");
+      // 前端校验：填写 TMDB ID 时必须选择媒体类型
+      if (tmdbid && !media_type) {
+          $("#media_mapping_type").addClass("is-invalid");
+          show_fail_modal("填写 TMDB ID 时必须选择媒体类型！");
+          return;
+      }
+      // 前端校验：不填写 TMDB ID 时必须填写映射名称
+      if (!tmdbid && !title) {
+          $("#media_mapping_title").addClass("is-invalid");
+          show_fail_modal("未填写 TMDB ID 时必须填写映射名称！");
+          return;
+      }
 
-      ajax_post("set_video_name_mapping", {key: raw_name, value: target}, function(ret) {
+      ajax_post("set_media_mapping", {
+          key: raw_name,
+          title: title,
+          type: media_type,
+          tmdbid: tmdbid
+      }, function(ret) {
           if (ret.code === 0) {
-              $("#modal-name-mapping").modal('hide');
+              $("#modal-media-mapping").modal('hide');
               show_success_modal(ret.msg, function() {
                   // 关闭成功提示后自动重新识别当前文件
                   mediafile_name_test(filename, "testresults_" + filepos);
@@ -244,17 +295,17 @@
       });
   }
 
-  // 删除名称映射
-  function delete_name_mapping() {
-      let raw_name = $("#name_mapping_source").val();
-      let filename = $("#name_mapping_filename_hidden").val();
-      let filepos = $("#name_mapping_filepos_hidden").val();
+  // 删除媒体映射
+  function delete_media_mapping() {
+      let raw_name = $("#media_mapping_source").val();
+      let filename = $("#media_mapping_filename_hidden").val();
+      let filepos = $("#media_mapping_filepos_hidden").val();
 
-      show_confirm_modal("确定要删除该名称映射吗？", function() {
+      show_confirm_modal("确定要删除该媒体映射吗？", function() {
           hide_confirm_modal();
-          ajax_post("delete_video_name_mapping", {key: raw_name}, function(ret) {
+          ajax_post("delete_media_mapping", {key: raw_name}, function(ret) {
               if (ret.code === 0) {
-                  $("#modal-name-mapping").modal('hide');
+                  $("#modal-media-mapping").modal('hide');
                   show_success_modal(ret.msg, function() {
                       // 关闭成功提示后自动重新识别当前文件
                       mediafile_name_test(filename, "testresults_" + filepos);
@@ -571,7 +622,7 @@
             <div class="col-auto">
               <div class="mt-1 btn-list">
                 <button onclick='mediafile_name_test("{FILENAME}", "testresults_{FILEPOS}")' class="btn btn-sm btn-pill">识别</button>
-                <button onclick='show_name_mapping_modal("{FILENAME}", "{FILEPOS}")' class="btn btn-sm btn-pill">名称映射</button>
+                <button onclick='show_media_mapping_modal("{FILENAME}", "{FILEPOS}")' class="btn btn-sm btn-pill">媒体映射</button>
                 <button onclick='mediafile_transfer("{FILENAME}", "{FILEPOS}")' class="btn btn-sm btn-pill">转移</button>
                 <button onclick='mediafile_scraper("{FILENAME}", "{FILEPOS}")' class="btn btn-sm btn-pill">刮削</button>
                 <button onclick='mediafile_subtitle("{FILENAME}", "{FILEPOS}")' class="btn btn-sm btn-pill">下载字幕</button>


### PR DESCRIPTION
## Summary

统一媒体映射配置，用 `media_mapping.yaml` 替代 `video_name_mapping.yaml` 和 `tmdb_id_mapping.conf`，文件管理页可用同一个配置完成名称映射和 TMDB ID 指定。

## Changes

- **config.py**: 新增 media_mapping 配置层（init/get/set/delete/list/save），删除 tmdb_id_mapping 和视频名称映射死代码
- **app/media/media.py**: 新增 `__apply_media_mapping()`，支持 title/type/tmdbid 三种映射行为
- **app/media/meta/metavideo.py**: 从 `__fix_name()` 移除 `get_video_name_mapping` 调用
- **web/action.py**: 新增 `get_media_mappings`/`set_media_mapping`/`delete_media_mapping`，删除旧 action
- **web/templates/rename/mediafile.html**: 按钮改为「媒体映射」，弹窗支持 title/type/tmdbid 配置
- **scripts/migrate_video_name_mapping.py**: 历史数据迁移脚本
- **tests/test_media_mapping.py**: 18 个单元测试
- **tests/test_media_mapping_migration.py**: 9 个迁移脚本测试

## Test plan

- [ ] 27 个单元测试全部通过
- [ ] 迁移脚本 dry-run 和实际迁移验证
- [ ] 文件管理页「媒体映射」弹窗手工验证
- [ ] 识别和刮削一致性验证

## Migration

```bash
# 预览
python scripts/migrate_video_name_mapping.py --source video_name_mapping.yaml --target media_mapping.yaml --dry-run

# 执行
python scripts/migrate_video_name_mapping.py --source video_name_mapping.yaml --target media_mapping.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)